### PR TITLE
Add \begin{align} support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [#389: Padding is not respected with `\cases`][issue-389], thanks @Orace.
 
 ### Added
+- Support for `\begin{align}`, see [#393][pull-393], thanks @Orace.
 - The README file is now packed into NuGet for better documentation.
 
 ## [1.0.0] - 2023-02-07
@@ -274,6 +275,7 @@ This was the initially published version. It consisted entirely of the original 
 [pull-277]: https://github.com/ForNeVeR/xaml-math/pull/277
 [pull-283]: https://github.com/ForNeVeR/xaml-math/pull/283
 [pull-329]: https://github.com/ForNeVeR/xaml-math/pull/329
+[pull-393]: https://github.com/ForNeVeR/xaml-math/pull/393
 
 [0.1.0]: https://github.com/ForNeVeR/xaml-math/releases/tag/0.1.0
 [0.2.0]: https://github.com/ForNeVeR/xaml-math/compare/0.1.0...0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] (1.0.1)
+## [Unreleased] (1.1.0)
 ### Fixed
 - [#387: Alignment issue in matrix with an empty cell][issue-387], thanks @Orace.
 - [#389: Padding is not respected with `\cases`][issue-389], thanks @Orace.

--- a/api/XamlMath.Shared.net462.verified.cs
+++ b/api/XamlMath.Shared.net462.verified.cs
@@ -45,6 +45,7 @@ namespace XamlMath
     {
         Left = 0,
         Center = 1,
+        Aligned = 2,
     }
     public partial class SourceSpan : System.IEquatable<XamlMath.SourceSpan>
     {

--- a/api/XamlMath.Shared.net6.0.verified.cs
+++ b/api/XamlMath.Shared.net6.0.verified.cs
@@ -45,6 +45,7 @@ namespace XamlMath
     {
         Left = 0,
         Center = 1,
+        Aligned = 2,
     }
     public partial class SourceSpan : System.IEquatable<XamlMath.SourceSpan>
     {

--- a/api/XamlMath.Shared.netstandard2.0.verified.cs
+++ b/api/XamlMath.Shared.netstandard2.0.verified.cs
@@ -45,6 +45,7 @@ namespace XamlMath
     {
         Left = 0,
         Center = 1,
+        Aligned = 2,
     }
     public partial class SourceSpan : System.IEquatable<XamlMath.SourceSpan>
     {

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -8,13 +8,25 @@ List of currently supported environment names:
 
 - `pmatrix`: works the same as the [corresponding matrix command][docs.matrices].
 
-Examples:
-```tex
-\begin{pmatrix} a & b & c \\ d & e & f \end{pmatrix}
-```
-This works the same as:
-```tex
-\pmatrix{a & b & c \\ d & e & f}
-```
+  Examples:
+  ```tex
+  \begin{pmatrix} a & b & c \\ d & e & f \end{pmatrix}
+  ```
+  This works the same as:
+  ```tex
+  \pmatrix{a & b & c \\ d & e & f}
+  ```
+
+- `align`: used for equation alignment.
+
+  For example, this will make the left and right parts of equations aligned:
+  ```tex
+  \begin{align} x+1 &= y + 1 \\ x &= y-1 \end{align}
+  ```
+
+  And this will allow to put the equations into several columns:
+  ```tex
+  \begin{align} x+1 &= y + 1 & a &= b + 1 \\ x &= y-1 & b + a &= c \end{align}
+  ```
 
 [docs.matrices]: matrices.md

--- a/src/WpfMath.Tests/EnvironmentTests.fs
+++ b/src/WpfMath.Tests/EnvironmentTests.fs
@@ -11,6 +11,10 @@ let alignEnvironment(): unit =
     verifyParseResult @"\begin{align} x+1 &= y \\ x &= y-1 \end{align}"
 
 [<Fact>]
+let alignEnvironmentLarge(): unit =
+    verifyParseResult @"\begin{align} x+1 &= y & a*2 &= b \\ x &= y-1 & a &= \frac{b}{2} \end{align}"
+
+[<Fact>]
 let pMatrixEnvironment(): unit =
     verifyParseResult @"\begin{pmatrix}{line 1}\\line 2\end{pmatrix}"
 

--- a/src/WpfMath.Tests/EnvironmentTests.fs
+++ b/src/WpfMath.Tests/EnvironmentTests.fs
@@ -7,6 +7,10 @@ open WpfMath.Tests.Utils
 open XamlMath.Exceptions
 
 [<Fact>]
+let alignEnvironment(): unit =
+    verifyParseResult @"\begin{align} x+1 &= y \\ x &= y-1 \end{align}"
+
+[<Fact>]
 let pMatrixEnvironment(): unit =
     verifyParseResult @"\begin{pmatrix}{line 1}\\line 2\end{pmatrix}"
 

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironment.approved.txt
@@ -2,7 +2,7 @@
   "RootAtom": {
     "[AtomType]": "MatrixAtom",
     "HorizontalPadding": 0.35,
-    "MatrixCellAlignment": "Align",
+    "MatrixCellAlignment": "Aligned",
     "MatrixCells": [
       [
         {

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironment.approved.txt
@@ -1,0 +1,212 @@
+{
+  "RootAtom": {
+    "[AtomType]": "MatrixAtom",
+    "HorizontalPadding": 0.35,
+    "MatrixCellAlignment": "Align",
+    "MatrixCells": [
+      [
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "x",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 15,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 14
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "plus",
+              "Source": {
+                "End": 16,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 15
+              },
+              "Type": "BinaryOperator"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "1",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 17,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 16
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 18,
+            "Length": 5,
+            "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 20,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 19
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "y",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 22,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 21
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 23,
+            "Length": 10,
+            "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        }
+      ],
+      [
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "x",
+          "IsTextSymbol": false,
+          "Source": {
+            "End": 27,
+            "Length": 1,
+            "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+            "SourceName": "User input",
+            "Start": 26
+          },
+          "TextStyle": null,
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 30,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 29
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "y",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 32,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 31
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "minus",
+              "Source": {
+                "End": 33,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 32
+              },
+              "Type": "BinaryOperator"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "1",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 34,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+                "SourceName": "User input",
+                "Start": 33
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 34,
+            "Length": 21,
+            "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        }
+      ]
+    ],
+    "Source": {
+      "End": 46,
+      "Length": 45,
+      "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary",
+    "VerticalPadding": 0.35
+  },
+  "Source": {
+    "End": 46,
+    "Length": 46,
+    "Source": "\\begin{align} x+1 &= y \\\\ x &= y-1 \\end{align}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironmentLarge.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironmentLarge.approved.txt
@@ -1,0 +1,391 @@
+{
+  "RootAtom": {
+    "[AtomType]": "MatrixAtom",
+    "HorizontalPadding": 0.35,
+    "MatrixCellAlignment": "Align",
+    "MatrixCells": [
+      [
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "x",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 15,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 14
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "plus",
+              "Source": {
+                "End": 16,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 15
+              },
+              "Type": "BinaryOperator"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "1",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 17,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 16
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 18,
+            "Length": 5,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 20,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 19
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "y",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 22,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 21
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 23,
+            "Length": 10,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "a",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 26,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 25
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "ast",
+              "Source": {
+                "End": 27,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 26
+              },
+              "Type": "BinaryOperator"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "2",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 28,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 27
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 29,
+            "Length": 16,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 31,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 30
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "b",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 33,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 32
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 34,
+            "Length": 21,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        }
+      ],
+      [
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "x",
+          "IsTextSymbol": false,
+          "Source": {
+            "End": 38,
+            "Length": 1,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 37
+          },
+          "TextStyle": null,
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 41,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 40
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "y",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 43,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 42
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "minus",
+              "Source": {
+                "End": 44,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 43
+              },
+              "Type": "BinaryOperator"
+            },
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "1",
+              "IsTextSymbol": false,
+              "Source": {
+                "End": 45,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 44
+              },
+              "TextStyle": null,
+              "Type": "Ordinary"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 46,
+            "Length": 33,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 13
+          },
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "a",
+          "IsTextSymbol": false,
+          "Source": {
+            "End": 49,
+            "Length": 1,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 48
+          },
+          "TextStyle": null,
+          "Type": "Ordinary"
+        },
+        {
+          "[AtomType]": "RowAtom",
+          "Elements": [
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "IsTextSymbol": false,
+              "Name": "equals",
+              "Source": {
+                "End": 52,
+                "Length": 1,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 51
+              },
+              "Type": "Relation"
+            },
+            {
+              "[AtomType]": "FractionAtom",
+              "Denominator": {
+                "[AtomType]": "CharAtom",
+                "Character": "2",
+                "IsTextSymbol": false,
+                "Source": {
+                  "End": 63,
+                  "Length": 1,
+                  "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                  "SourceName": "User input",
+                  "Start": 62
+                },
+                "TextStyle": null,
+                "Type": "Ordinary"
+              },
+              "Numerator": {
+                "[AtomType]": "CharAtom",
+                "Character": "b",
+                "IsTextSymbol": false,
+                "Source": {
+                  "End": 60,
+                  "Length": 1,
+                  "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                  "SourceName": "User input",
+                  "Start": 59
+                },
+                "TextStyle": null,
+                "Type": "Ordinary"
+              },
+              "Source": {
+                "End": 64,
+                "Length": 10,
+                "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+                "SourceName": "User input",
+                "Start": 54
+              },
+              "Type": "Inner"
+            }
+          ],
+          "PreviousAtom": null,
+          "Source": {
+            "End": 104,
+            "Length": 64,
+            "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+            "SourceName": "User input",
+            "Start": 40
+          },
+          "Type": "Ordinary"
+        }
+      ]
+    ],
+    "Source": {
+      "End": 76,
+      "Length": 75,
+      "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary",
+    "VerticalPadding": 0.35
+  },
+  "Source": {
+    "End": 76,
+    "Length": 76,
+    "Source": "\\begin{align} x+1 &= y & a*2 &= b \\\\ x &= y-1 & a &= \\frac{b}{2} \\end{align}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironmentLarge.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.alignEnvironmentLarge.approved.txt
@@ -2,7 +2,7 @@
   "RootAtom": {
     "[AtomType]": "MatrixAtom",
     "HorizontalPadding": 0.35,
-    "MatrixCellAlignment": "Align",
+    "MatrixCellAlignment": "Aligned",
     "MatrixCells": [
       [
         {

--- a/src/XamlMath.Shared/Atoms/MatrixAtom.cs
+++ b/src/XamlMath.Shared/Atoms/MatrixAtom.cs
@@ -69,7 +69,7 @@ namespace XamlMath.Atoms
 
 
                     var hFreeSpace = columnWidth - cell.TotalWidth;
-                    var (lGap, rGap) = GetLeftRightGap(hFreeSpace);
+                    var (lGap, rGap) = GetLeftRightGap(hFreeSpace, j);
                     rowContainer.Add(new StrutBox(lGap, 0.0, 0.0, 0.0));
                     rowContainer.Add(cellContainer);
                     rowContainer.Add(new StrutBox(rGap, 0.0, 0.0, 0.0));
@@ -86,11 +86,17 @@ namespace XamlMath.Atoms
             return rowsContainer;
         }
 
-        private SurroundingGap GetLeftRightGap(double hFreeSpace)
+        private SurroundingGap GetLeftRightGap(double hFreeSpace, int columnIndex)
         {
             var lrPadding = HorizontalPadding / 2;
             return MatrixCellAlignment switch
             {
+                MatrixCellAlignment.Align => (columnIndex % 2) switch
+                {
+                    0 => new SurroundingGap(lrPadding + hFreeSpace, lrPadding),
+                    1 => new SurroundingGap(lrPadding, lrPadding + hFreeSpace),
+                    _ => throw new ArgumentOutOfRangeException()
+                },
                 MatrixCellAlignment.Left => new SurroundingGap(lrPadding, lrPadding + hFreeSpace),
                 MatrixCellAlignment.Center => new SurroundingGap(lrPadding + hFreeSpace / 2, lrPadding + hFreeSpace / 2),
                 _ => throw new ArgumentOutOfRangeException()

--- a/src/XamlMath.Shared/Atoms/MatrixAtom.cs
+++ b/src/XamlMath.Shared/Atoms/MatrixAtom.cs
@@ -1,11 +1,10 @@
+#if NET462
+using XamlMath.Compatibility;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using XamlMath.Boxes;
-#if NET462
-using XamlMath.Compatibility;
-#endif
-
 using SurroundingGap = System.Tuple<double, double>;
 
 namespace XamlMath.Atoms
@@ -13,7 +12,12 @@ namespace XamlMath.Atoms
     /// <summary>An atom representing a tabular arrangement of atoms.</summary>
     internal record MatrixAtom : Atom
     {
-        public const double AlignGroupLeftPadding = 4;
+        /// <summary>Used for grouping of align statements into several columns.</summary>
+        /// <remarks>
+        /// See section "Aligning several equations" of
+        /// <a href="https://www.overleaf.com/learn/latex/Aligning_equations_with_amsmath">this article</a> for details.
+        /// </remarks>
+        private const double AlignGroupLeftPadding = 4;
         public const double DefaultPadding = 0.35;
 
         public MatrixAtom(

--- a/src/XamlMath.Shared/Atoms/MatrixAtom.cs
+++ b/src/XamlMath.Shared/Atoms/MatrixAtom.cs
@@ -13,6 +13,7 @@ namespace XamlMath.Atoms
     /// <summary>An atom representing a tabular arrangement of atoms.</summary>
     internal record MatrixAtom : Atom
     {
+        public const double AlignGroupLeftPadding = 4;
         public const double DefaultPadding = 0.35;
 
         public MatrixAtom(
@@ -93,6 +94,7 @@ namespace XamlMath.Atoms
             {
                 MatrixCellAlignment.Align => (columnIndex % 2) switch
                 {
+                    0 when columnIndex != 0 => new SurroundingGap(AlignGroupLeftPadding + lrPadding + hFreeSpace, lrPadding),
                     0 => new SurroundingGap(lrPadding + hFreeSpace, lrPadding),
                     1 => new SurroundingGap(lrPadding, lrPadding + hFreeSpace),
                     _ => throw new ArgumentOutOfRangeException()

--- a/src/XamlMath.Shared/Atoms/MatrixAtom.cs
+++ b/src/XamlMath.Shared/Atoms/MatrixAtom.cs
@@ -96,7 +96,7 @@ namespace XamlMath.Atoms
             var lrPadding = HorizontalPadding / 2;
             return MatrixCellAlignment switch
             {
-                MatrixCellAlignment.Align => (columnIndex % 2) switch
+                MatrixCellAlignment.Aligned => (columnIndex % 2) switch
                 {
                     0 when columnIndex != 0 => new SurroundingGap(AlignGroupLeftPadding + lrPadding + hFreeSpace, lrPadding),
                     0 => new SurroundingGap(lrPadding + hFreeSpace, lrPadding),

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -8,7 +8,7 @@ namespace XamlMath.Parsers.Matrices
     /// <summary>A parser for matrix-like constructs.</summary>
     internal class MatrixCommandParser : ICommandParser, IEnvironmentParser
     {
-        internal static readonly MatrixCommandParser Align = new(null, null, MatrixCellAlignment.Align);
+        internal static readonly MatrixCommandParser Align = new(null, null, MatrixCellAlignment.Aligned);
         internal static readonly MatrixCommandParser Cases = new("lbrace", null, MatrixCellAlignment.Left);
         internal static readonly MatrixCommandParser Matrix = new(null, null, MatrixCellAlignment.Center);
         internal static readonly MatrixCommandParser PMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center);

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -8,6 +8,7 @@ namespace XamlMath.Parsers.Matrices
     /// <summary>A parser for matrix-like constructs.</summary>
     internal class MatrixCommandParser : ICommandParser, IEnvironmentParser
     {
+        internal static readonly MatrixCommandParser Align = new(null, null, MatrixCellAlignment.Align);
         internal static readonly MatrixCommandParser Cases = new("lbrace", null, MatrixCellAlignment.Left);
         internal static readonly MatrixCommandParser Matrix = new(null, null, MatrixCellAlignment.Center);
         internal static readonly MatrixCommandParser PMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center);

--- a/src/XamlMath.Shared/Parsers/StandardCommands.cs
+++ b/src/XamlMath.Shared/Parsers/StandardCommands.cs
@@ -110,6 +110,7 @@ namespace XamlMath.Parsers
         internal static readonly IReadOnlyDictionary<string, IEnvironmentParser> Environments =
             new Dictionary<string, IEnvironmentParser>
             {
+                ["align"] = MatrixCommandParser.Align,
                 ["pmatrix"] = MatrixCommandParser.PMatrix
             };
     }

--- a/src/XamlMath.Shared/TexEnums.cs
+++ b/src/XamlMath.Shared/TexEnums.cs
@@ -2,9 +2,9 @@ namespace XamlMath
 {
     public enum MatrixCellAlignment
     {
-        Align,
         Left,
-        Center
+        Center,
+        Aligned
     }
 
     public enum TexDelimeterType

--- a/src/XamlMath.Shared/TexEnums.cs
+++ b/src/XamlMath.Shared/TexEnums.cs
@@ -2,6 +2,7 @@ namespace XamlMath
 {
     public enum MatrixCellAlignment
     {
+        Align,
         Left,
         Center
     }


### PR DESCRIPTION
This may fix #381.

![\begin{align} x+1&=y \\ x&=y-1 \end{align}](https://user-images.githubusercontent.com/9695349/234570777-71417fed-7f30-4548-8526-d50af17ea6bc.png)

WIP: 
- [x] Depend on #392.
- [x] Validate `AlignGroupLeftPadding` value (currently set to 4).
- [x] For more than 2 column, the space before odd columns should be bigger. (how bigger ?)
