### PR TITLE
Packaging: remove unsupported license expressions

### DIFF
--- a/src/AvaloniaMath/AvaloniaMath.csproj
+++ b/src/AvaloniaMath/AvaloniaMath.csproj
@@ -8,7 +8,7 @@
     <PropertyGroup>
         <PackageId>AvaloniaMath</PackageId>
         <Title>Avalonia-Math</Title>
-        <PackageLicenseExpression>MIT AND Knuth-CTAN AND OFL-1.1</PackageLicenseExpression>
+        <PackageLicenseExpression>MIT AND OFL-1.1</PackageLicenseExpression>
         <PackageTags>$(PackageTags);avalonia</PackageTags>
         <Description>.NET library for rendering mathematical formulae using the LaTeX typsetting style, for the Avalonia framework.</Description>
     </PropertyGroup>

--- a/src/WpfMath/WpfMath.csproj
+++ b/src/WpfMath/WpfMath.csproj
@@ -8,7 +8,7 @@
     <PropertyGroup>
         <PackageId>WpfMath</PackageId>
         <Title>WPF-Math</Title>
-        <PackageLicenseExpression>MIT AND Knuth-CTAN AND OFL-1.1</PackageLicenseExpression>
+        <PackageLicenseExpression>MIT AND OFL-1.1</PackageLicenseExpression>
         <Description>.NET library for rendering mathematical formulae using the LaTeX typsetting style, for the WPF framework.</Description>
         <PackageTags>$(PackageTags);wpf</PackageTags>
     </PropertyGroup>


### PR DESCRIPTION
We are still going to state Knuth-CTAN in the documentation, but there's no way to tell this in NuGet metadata, unfortunately.