### PR TITLE
Sealed exception types in `XamlMath.Shared\Exceptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] (2.1.1)
+### Changed
+- The exception classes are now `sealed` (should not break anything, since there never was any sense in extending them in the user code).
+
 ## [2.1.0] - 2023-07-15
 ### Changed
 - AvaloniaMath is now based on (and thus compatible with) Avalonia 11.

--- a/api/WpfMath.net462.verified.cs
+++ b/api/WpfMath.net462.verified.cs
@@ -37,10 +37,10 @@ namespace WpfMath.Controls
         public int SelectionLength { get { throw null; } set { } }
         public int SelectionStart { get { throw null; } set { } }
         public string SystemTextFontName { get { throw null; } set { } }
-        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.9.0")]
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.10.0")]
         [System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void InitializeComponent() { }
-        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.9.0")]
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.10.0")]
         [System.ComponentModel.EditorBrowsableAttribute(1)]
         [System.Diagnostics.DebuggerNonUserCodeAttribute]
         void System.Windows.Markup.IComponentConnector.Connect(int connectionId, object target) { }

--- a/api/WpfMath.net6.0.verified.cs
+++ b/api/WpfMath.net6.0.verified.cs
@@ -37,10 +37,10 @@ namespace WpfMath.Controls
         public int SelectionLength { get { throw null; } set { } }
         public int SelectionStart { get { throw null; } set { } }
         public string SystemTextFontName { get { throw null; } set { } }
-        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.9.0")]
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.10.0")]
         [System.Diagnostics.DebuggerNonUserCodeAttribute]
         public void InitializeComponent() { }
-        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.9.0")]
+        [System.CodeDom.Compiler.GeneratedCodeAttribute("PresentationBuildTasks", "7.0.10.0")]
         [System.ComponentModel.EditorBrowsableAttribute(1)]
         [System.Diagnostics.DebuggerNonUserCodeAttribute]
         void System.Windows.Markup.IComponentConnector.Connect(int connectionId, object target) { }

--- a/api/XamlMath.Shared.net462.verified.cs
+++ b/api/XamlMath.Shared.net462.verified.cs
@@ -252,7 +252,7 @@ namespace XamlMath.Colors
 }
 namespace XamlMath.Exceptions
 {
-    public partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         public TexCharacterMappingNotFoundException(string message) { }
     }
@@ -262,19 +262,19 @@ namespace XamlMath.Exceptions
         public TexException(string message) { }
         public TexException(string message, System.Exception innerException) { }
     }
-    public partial class TexNotSupportedException : XamlMath.Exceptions.TexException
+    public sealed partial class TexNotSupportedException : XamlMath.Exceptions.TexException
     {
         public TexNotSupportedException(string message) { }
     }
-    public partial class TexParseException : XamlMath.Exceptions.TexException
+    public sealed partial class TexParseException : XamlMath.Exceptions.TexException
     {
         internal TexParseException() { }
     }
-    public partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         internal TextStyleMappingNotFoundException() { }
     }
-    public partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
     {
         public TypeFaceNotFoundException(string message) { }
     }

--- a/api/XamlMath.Shared.net6.0.verified.cs
+++ b/api/XamlMath.Shared.net6.0.verified.cs
@@ -252,7 +252,7 @@ namespace XamlMath.Colors
 }
 namespace XamlMath.Exceptions
 {
-    public partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         public TexCharacterMappingNotFoundException(string message) { }
     }
@@ -262,19 +262,19 @@ namespace XamlMath.Exceptions
         public TexException(string message) { }
         public TexException(string message, System.Exception innerException) { }
     }
-    public partial class TexNotSupportedException : XamlMath.Exceptions.TexException
+    public sealed partial class TexNotSupportedException : XamlMath.Exceptions.TexException
     {
         public TexNotSupportedException(string message) { }
     }
-    public partial class TexParseException : XamlMath.Exceptions.TexException
+    public sealed partial class TexParseException : XamlMath.Exceptions.TexException
     {
         internal TexParseException() { }
     }
-    public partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         internal TextStyleMappingNotFoundException() { }
     }
-    public partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
     {
         public TypeFaceNotFoundException(string message) { }
     }

--- a/api/XamlMath.Shared.netstandard2.0.verified.cs
+++ b/api/XamlMath.Shared.netstandard2.0.verified.cs
@@ -252,7 +252,7 @@ namespace XamlMath.Colors
 }
 namespace XamlMath.Exceptions
 {
-    public partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TexCharacterMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         public TexCharacterMappingNotFoundException(string message) { }
     }
@@ -262,19 +262,19 @@ namespace XamlMath.Exceptions
         public TexException(string message) { }
         public TexException(string message, System.Exception innerException) { }
     }
-    public partial class TexNotSupportedException : XamlMath.Exceptions.TexException
+    public sealed partial class TexNotSupportedException : XamlMath.Exceptions.TexException
     {
         public TexNotSupportedException(string message) { }
     }
-    public partial class TexParseException : XamlMath.Exceptions.TexException
+    public sealed partial class TexParseException : XamlMath.Exceptions.TexException
     {
         internal TexParseException() { }
     }
-    public partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TextStyleMappingNotFoundException : XamlMath.Exceptions.TexException
     {
         internal TextStyleMappingNotFoundException() { }
     }
-    public partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
+    public sealed partial class TypeFaceNotFoundException : XamlMath.Exceptions.TexException
     {
         public TypeFaceNotFoundException(string message) { }
     }

--- a/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
@@ -1,8 +1,9 @@
-namespace XamlMath.Exceptions;
-
-public sealed class TexCharacterMappingNotFoundException : TexException
+namespace XamlMath.Exceptions
 {
-    public TexCharacterMappingNotFoundException(string message) : base(message)
+    public sealed class TexCharacterMappingNotFoundException : TexException
     {
+        public TexCharacterMappingNotFoundException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TexCharacterMappingNotFoundException : TexException
 {
-    public sealed class TexCharacterMappingNotFoundException : TexException
+    public TexCharacterMappingNotFoundException(string message) : base(message)
     {
-        public TexCharacterMappingNotFoundException(string message) : base(message)
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexCharacterMappingNotFoundException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TexCharacterMappingNotFoundException : TexException
 {
-    public class TexCharacterMappingNotFoundException : TexException
+    public TexCharacterMappingNotFoundException(string message) : base(message)
     {
-        public TexCharacterMappingNotFoundException(string message) : base(message)
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexException.cs
@@ -1,18 +1,19 @@
 using System;
 
-namespace XamlMath.Exceptions;
-
-public abstract class TexException : Exception
+namespace XamlMath.Exceptions
 {
-    public TexException()
+    public abstract class TexException : Exception
     {
-    }
+        public TexException()
+        {
+        }
 
-    public TexException(string message) : base(message)
-    {
-    }
+        public TexException(string message) : base(message)
+        {
+        }
 
-    public TexException(string message, Exception innerException) : base(message, innerException)
-    {
+        public TexException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexException.cs
@@ -1,19 +1,18 @@
 using System;
 
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public abstract class TexException : Exception
 {
-    public abstract class TexException : Exception
+    public TexException()
     {
-        public TexException()
-        {
-        }
+    }
 
-        public TexException(string message) : base(message)
-        {
-        }
+    public TexException(string message) : base(message)
+    {
+    }
 
-        public TexException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
+    public TexException(string message, Exception innerException) : base(message, innerException)
+    {
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TexNotSupportedException : TexException
 {
-    public class TexNotSupportedException : TexException
+    public TexNotSupportedException(string message) : base(message)
     {
-        public TexNotSupportedException(string message) : base(message)
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
@@ -1,8 +1,9 @@
-namespace XamlMath.Exceptions;
-
-public sealed class TexNotSupportedException : TexException
+namespace XamlMath.Exceptions
 {
-    public TexNotSupportedException(string message) : base(message)
+    public sealed class TexNotSupportedException : TexException
     {
+        public TexNotSupportedException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexNotSupportedException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TexNotSupportedException : TexException
 {
-    public sealed class TexNotSupportedException : TexException
+    public TexNotSupportedException(string message) : base(message)
     {
-        public TexNotSupportedException(string message) : base(message)
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexParseException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexParseException.cs
@@ -1,17 +1,16 @@
 using System;
 
-namespace XamlMath.Exceptions
-{
-    public sealed class TexParseException : TexException
-    {
-        internal TexParseException(string message)
-            : base(message)
-        {
-        }
+namespace XamlMath.Exceptions;
 
-        internal TexParseException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
+public sealed class TexParseException : TexException
+{
+    internal TexParseException(string message)
+        : base(message)
+    {
+    }
+
+    internal TexParseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexParseException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexParseException.cs
@@ -1,16 +1,17 @@
 using System;
 
-namespace XamlMath.Exceptions;
-
-public sealed class TexParseException : TexException
+namespace XamlMath.Exceptions
 {
-    internal TexParseException(string message)
-        : base(message)
+    public sealed class TexParseException : TexException
     {
-    }
+        internal TexParseException(string message)
+            : base(message)
+        {
+        }
 
-    internal TexParseException(string message, Exception innerException)
-        : base(message, innerException)
-    {
+        internal TexParseException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TexParseException.cs
+++ b/src/XamlMath.Shared/Exceptions/TexParseException.cs
@@ -1,17 +1,16 @@
 using System;
 
-namespace XamlMath.Exceptions
-{
-    public class TexParseException : TexException
-    {
-        internal TexParseException(string message)
-            : base(message)
-        {
-        }
+namespace XamlMath.Exceptions;
 
-        internal TexParseException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
+public sealed class TexParseException : TexException
+{
+    internal TexParseException(string message)
+        : base(message)
+    {
+    }
+
+    internal TexParseException(string message, Exception innerException)
+        : base(message, innerException)
+    {
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
@@ -1,10 +1,9 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TextStyleMappingNotFoundException : TexException
 {
-    public sealed class TextStyleMappingNotFoundException : TexException
+    internal TextStyleMappingNotFoundException(string textStyleName)
+        : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
     {
-        internal TextStyleMappingNotFoundException(string textStyleName)
-            : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
@@ -1,10 +1,9 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TextStyleMappingNotFoundException : TexException
 {
-    public class TextStyleMappingNotFoundException : TexException
+    internal TextStyleMappingNotFoundException(string textStyleName)
+        : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
     {
-        internal TextStyleMappingNotFoundException(string textStyleName)
-            : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
@@ -1,9 +1,10 @@
-namespace XamlMath.Exceptions;
-
-public sealed class TextStyleMappingNotFoundException : TexException
+namespace XamlMath.Exceptions
 {
-    internal TextStyleMappingNotFoundException(string textStyleName)
-        : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
+    public sealed class TextStyleMappingNotFoundException : TexException
     {
+        internal TextStyleMappingNotFoundException(string textStyleName)
+            : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TypeFaceNotFoundException : TexException
 {
-    public class TypeFaceNotFoundException : TexException
+    public TypeFaceNotFoundException(string message) : base(message)
     {
-        public TypeFaceNotFoundException(string message) : base(message)
-        {
-        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
@@ -1,8 +1,9 @@
-namespace XamlMath.Exceptions;
-
-public sealed class TypeFaceNotFoundException : TexException
+namespace XamlMath.Exceptions
 {
-    public TypeFaceNotFoundException(string message) : base(message)
+    public sealed class TypeFaceNotFoundException : TexException
     {
+        public TypeFaceNotFoundException(string message) : base(message)
+        {
+        }
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TypeFaceNotFoundException.cs
@@ -1,9 +1,8 @@
-namespace XamlMath.Exceptions
+namespace XamlMath.Exceptions;
+
+public sealed class TypeFaceNotFoundException : TexException
 {
-    public sealed class TypeFaceNotFoundException : TexException
+    public TypeFaceNotFoundException(string message) : base(message)
     {
-        public TypeFaceNotFoundException(string message) : base(message)
-        {
-        }
     }
 }


### PR DESCRIPTION
Also, modernized namespace references (they are now file-scoped).

P.S. I don't know what is causing the build errors. Does sealing exception classes do anything that may cause them?