### PR TITLE
Private fields which are never modified were made `readonly`

### DIFF
--- a/src/WpfMath/Controls/FormulaControl.xaml.cs
+++ b/src/WpfMath/Controls/FormulaControl.xaml.cs
@@ -17,7 +17,7 @@ namespace WpfMath.Controls
     /// </summary>
     public partial class FormulaControl : UserControl
     {
-        private static TexFormulaParser _formulaParser = WpfTeXFormulaParser.Instance;
+        private static readonly TexFormulaParser _formulaParser = WpfTeXFormulaParser.Instance;
         private TexFormula? texFormula;
 
         public string Formula

--- a/src/XamlMath.Shared/Atoms/RowAtom.cs
+++ b/src/XamlMath.Shared/Atoms/RowAtom.cs
@@ -10,10 +10,10 @@ namespace XamlMath.Atoms
     internal record RowAtom : Atom, IRow
     {
         // Set of atom types that make previous atom of BinaryOperator type change to Ordinary type.
-        private static BitArray binaryOperatorChangeSet;
+        private static readonly BitArray binaryOperatorChangeSet;
 
         // Set of atom types that may need kern, or together with previous atom, be replaced by ligature.
-        private static BitArray ligatureKernChangeSet;
+        private static readonly BitArray ligatureKernChangeSet;
 
         static RowAtom()
         {

--- a/src/XamlMath.Shared/Atoms/SpaceAtom.cs
+++ b/src/XamlMath.Shared/Atoms/SpaceAtom.cs
@@ -7,7 +7,7 @@ namespace XamlMath.Atoms
     internal record SpaceAtom : Atom
     {
         // Collection of unit conversion functions.
-        private static UnitConversion[] unitConversions = new UnitConversion[]
+        private static readonly UnitConversion[] unitConversions = new UnitConversion[]
                 {
                     new UnitConversion(e => e.MathFont.GetXHeight(e.Style, e.LastFontId)),
 

--- a/src/XamlMath.Shared/Atoms/SymbolAtom.cs
+++ b/src/XamlMath.Shared/Atoms/SymbolAtom.cs
@@ -21,7 +21,7 @@ namespace XamlMath.Atoms
         private static readonly IDictionary<string, Func<SourceSpan?, SymbolAtom>> symbols;
 
         // Set of all valid symbol types.
-        private static BitArray validSymbolTypes;
+        private static readonly BitArray validSymbolTypes;
 
         static SymbolAtom()
         {

--- a/src/XamlMath.Shared/Boxes/Box.cs
+++ b/src/XamlMath.Shared/Boxes/Box.cs
@@ -7,8 +7,8 @@ namespace XamlMath.Boxes
     // Represents graphical box that is part of math expression, and can itself contain child boxes.
     public abstract class Box
     {
-        private List<Box> children;
-        private ReadOnlyCollection<Box> childrenReadOnly;
+        private readonly List<Box> children;
+        private readonly ReadOnlyCollection<Box> childrenReadOnly;
 
         internal Box(TexEnvironment environment)
             : this(environment.Foreground, environment.Background)

--- a/src/XamlMath.Shared/DefaultTexFontParser.cs
+++ b/src/XamlMath.Shared/DefaultTexFontParser.cs
@@ -44,9 +44,9 @@ namespace XamlMath
             charChildParsers.Add("Extension", new ExtensionParser());
         }
 
-        private IDictionary<string, CharFont[]> parsedTextStyles;
+        private readonly IDictionary<string, CharFont[]> parsedTextStyles;
 
-        private XElement rootElement;
+        private readonly XElement rootElement;
 
         public DefaultTexFontParser(IFontProvider fontProvider)
         {

--- a/src/XamlMath.Shared/GlueSettingsParser.cs
+++ b/src/XamlMath.Shared/GlueSettingsParser.cs
@@ -11,8 +11,8 @@ namespace XamlMath
     {
         private static readonly string resourceName = TexUtilities.ResourcesDataDirectory + "GlueSettings.xml";
 
-        private static IDictionary<string, TexAtomType> typeMappings;
-        private static IDictionary<string, TexStyle> styleMappings;
+        private static readonly IDictionary<string, TexAtomType> typeMappings;
+        private static readonly IDictionary<string, TexStyle> styleMappings;
 
         static GlueSettingsParser()
         {
@@ -52,10 +52,10 @@ namespace XamlMath
             styleMappings.Add("script_script", (TexStyle)((int)TexStyle.ScriptScript / 2));
         }
 
-        private IList<Glue> glueTypes;
-        private IDictionary<string, int> glueTypeMappings;
+        private readonly IList<Glue> glueTypes;
+        private readonly IDictionary<string, int> glueTypeMappings;
 
-        private XElement rootElement;
+        private readonly XElement rootElement;
 
         public GlueSettingsParser()
         {

--- a/src/XamlMath.Shared/TexPredefinedFormulaSettingsParser.cs
+++ b/src/XamlMath.Shared/TexPredefinedFormulaSettingsParser.cs
@@ -28,7 +28,7 @@ namespace XamlMath
             }
         }
 
-        private XElement rootElement;
+        private readonly XElement rootElement;
 
         public TexPredefinedFormulaSettingsParser()
         {

--- a/src/XamlMath.Shared/TexSymbolParser.cs
+++ b/src/XamlMath.Shared/TexSymbolParser.cs
@@ -12,7 +12,7 @@ namespace XamlMath
     {
         private static readonly string resourceName = TexUtilities.ResourcesDataDirectory + "TexSymbols.xml";
 
-        private static IDictionary<string, TexAtomType> typeMappings;
+        private static readonly IDictionary<string, TexAtomType> typeMappings;
 
         static TexSymbolParser()
         {
@@ -33,7 +33,7 @@ namespace XamlMath
             typeMappings.Add("acc", TexAtomType.Accent);
         }
 
-        private XElement rootElement;
+        private readonly XElement rootElement;
 
         public TexSymbolParser()
         {


### PR DESCRIPTION
Done automatically by IDE, but occurrences were few, so reviewing it shouldn't be too daunting