### PR TITLE
Internal refactoring - little nudge towards immutable code

### DIFF
--- a/src/XamlMath.Shared/Atoms/SymbolAtom.cs
+++ b/src/XamlMath.Shared/Atoms/SymbolAtom.cs
@@ -10,7 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace XamlMath.Atoms
 {
     // Atom representing symbol (non-alphanumeric character).
-    internal record SymbolAtom : CharSymbol
+    internal sealed record SymbolAtom : CharSymbol
     {
         /// <summary>
         /// Special name of empty delimiter symbol that shouldn't be rendered.
@@ -18,7 +18,7 @@ namespace XamlMath.Atoms
         internal const string EmptyDelimiterName = "_emptyDelimiter";
 
         // Dictionary of definitions of all symbols, keyed by name.
-        private static readonly IDictionary<string, Func<SourceSpan?, SymbolAtom>> symbols;
+        private static readonly IReadOnlyDictionary<string, Func<SourceSpan?, SymbolAtom>> symbols;
 
         // Set of all valid symbol types.
         private static readonly BitArray validSymbolTypes;

--- a/src/XamlMath.Shared/Glue.cs
+++ b/src/XamlMath.Shared/Glue.cs
@@ -4,9 +4,9 @@ using XamlMath.Boxes;
 namespace XamlMath
 {
     // Represents glueElement for holding together boxes.
-    internal class Glue
+    internal sealed class Glue
     {
-        private static readonly IList<Glue> glueTypes;
+        private static readonly IReadOnlyList<Glue> glueTypes;
         private static readonly int[, ,] glueRules;
 
         static Glue()

--- a/src/XamlMath.Shared/TexFontInfo.cs
+++ b/src/XamlMath.Shared/TexFontInfo.cs
@@ -7,7 +7,7 @@ using XamlMath.Utils;
 namespace XamlMath
 {
     // Specifies all information about single font.
-    internal class TexFontInfo
+    internal sealed class TexFontInfo
     {
         public const int charCodesCount = 256;
 

--- a/src/XamlMath.Shared/TexFormulaParser.cs
+++ b/src/XamlMath.Shared/TexFormulaParser.cs
@@ -21,6 +21,7 @@ namespace XamlMath
 
         internal const char leftGroupChar = '{';
         internal const char rightGroupChar = '}';
+
         private const char leftBracketChar = '[';
         private const char rightBracketChar = ']';
 
@@ -32,7 +33,7 @@ namespace XamlMath
         /// A set of names of the commands that are embedded in the parser itself, <see cref="ProcessCommand"/>.
         /// These're not the additional commands that may be supplied via <see cref="_commandRegistry"/>.
         /// </summary>
-        private static readonly HashSet<string> embeddedCommands = new HashSet<string>
+        private static readonly HashSet<string> embeddedCommands = new()
         {
             "color",
             "colorbox",
@@ -43,13 +44,14 @@ namespace XamlMath
             "sqrt"
         };
 
-        private static readonly IList<string> symbols;
-        private static readonly IList<string> delimeters;
+        private static readonly IReadOnlyList<string> symbols;
+        private static readonly IReadOnlyList<string> delimeters;
         private static readonly HashSet<string> textStyles;
+
         // TODO[#339]: Architectural solution to make this work faster.
         private readonly IReadOnlyDictionary<string, Func<SourceSpan, TexFormula?>> predefinedFormulas;
 
-        private static readonly string[][] delimiterNames =
+        private static readonly IReadOnlyList<IReadOnlyList<string>> delimiterNames = new[] 
         {
             new[] { "lbrace", "rbrace" },
             new[] { "(", ")" },
@@ -69,10 +71,10 @@ namespace XamlMath
             var formulaSettingsParser = new TexPredefinedFormulaSettingsParser();
             symbols = formulaSettingsParser.GetSymbolMappings();
             delimeters = formulaSettingsParser.GetDelimiterMappings();
-            textStyles = formulaSettingsParser.GetTextStyles();
+            textStyles = new HashSet<string>(formulaSettingsParser.GetTextStyles());
         }
 
-        internal static string[][] DelimiterNames => delimiterNames;
+        internal static IReadOnlyList<IReadOnlyList<string>> DelimiterNames => delimiterNames;
 
         internal static string GetDelimeterMapping(char character)
         {

--- a/src/XamlMath.Shared/TexPredefinedFormulaSettingsParser.cs
+++ b/src/XamlMath.Shared/TexPredefinedFormulaSettingsParser.cs
@@ -7,7 +7,7 @@ using XamlMath.Utils;
 namespace XamlMath
 {
     // Parses settings for predefined formulas from XML file.
-    internal class TexPredefinedFormulaSettingsParser
+    internal sealed class TexPredefinedFormulaSettingsParser
     {
         private static readonly string resourceName = TexUtilities.ResourcesDataDirectory + "TexFormulaSettings.xml";
 
@@ -37,7 +37,7 @@ namespace XamlMath
             this.rootElement = doc.Root;
         }
 
-        public IList<string> GetSymbolMappings()
+        public IReadOnlyList<string> GetSymbolMappings()
         {
             var mappings = new string[TexFontInfo.charCodesCount];
             var charToSymbol = rootElement.Element("CharacterToSymbolMappings");
@@ -46,7 +46,7 @@ namespace XamlMath
             return mappings;
         }
 
-        public IList<string> GetDelimiterMappings()
+        public IReadOnlyList<string> GetDelimiterMappings()
         {
             var mappings = new string[TexFontInfo.charCodesCount];
             var charToDelimiter = rootElement.Element("CharacterToDelimiterMappings");
@@ -55,22 +55,16 @@ namespace XamlMath
             return mappings;
         }
 
-        public HashSet<string> GetTextStyles()
+        public IEnumerable<string> GetTextStyles()
         {
-            var result = new HashSet<string>();
-
             var textStyles = rootElement.Element("TextStyles");
-            if (textStyles != null)
+            if (textStyles == null) yield break;
+            foreach (var textStyleElement in textStyles.Elements("TextStyle"))
             {
-                foreach (var textStyleElement in textStyles.Elements("TextStyle"))
-                {
-                    var name = textStyleElement.AttributeValue("name");
-                    Debug.Assert(name != null);
-                    result.Add(name);
-                }
+                var name = textStyleElement.AttributeValue("name");
+                Debug.Assert(name != null);
+                yield return name;
             }
-
-            return result;
         }
     }
 }

--- a/src/XamlMath.Shared/TexSymbolParser.cs
+++ b/src/XamlMath.Shared/TexSymbolParser.cs
@@ -8,29 +8,25 @@ using XamlMath.Utils;
 namespace XamlMath
 {
     // Parse definitions of symbols from XML files.
-    internal class TexSymbolParser
+    internal sealed class TexSymbolParser
     {
         private static readonly string resourceName = TexUtilities.ResourcesDataDirectory + "TexSymbols.xml";
 
-        private static readonly IDictionary<string, TexAtomType> typeMappings;
+        private static readonly IReadOnlyDictionary<string, TexAtomType> typeMappings;
 
         static TexSymbolParser()
         {
-            typeMappings = new Dictionary<string, TexAtomType>();
-
-            SetTypeMappings();
-        }
-
-        private static void SetTypeMappings()
-        {
-            typeMappings.Add("ord", TexAtomType.Ordinary);
-            typeMappings.Add("op", TexAtomType.BigOperator);
-            typeMappings.Add("bin", TexAtomType.BinaryOperator);
-            typeMappings.Add("rel", TexAtomType.Relation);
-            typeMappings.Add("open", TexAtomType.Opening);
-            typeMappings.Add("close", TexAtomType.Closing);
-            typeMappings.Add("punct", TexAtomType.Punctuation);
-            typeMappings.Add("acc", TexAtomType.Accent);
+            typeMappings = new Dictionary<string, TexAtomType>
+            {
+                ["ord"] = TexAtomType.Ordinary,
+                ["op"] = TexAtomType.BigOperator,
+                ["bin"] = TexAtomType.BinaryOperator,
+                ["rel"] = TexAtomType.Relation,
+                ["open"] = TexAtomType.Opening,
+                ["close"] = TexAtomType.Closing,
+                ["punct"] = TexAtomType.Punctuation,
+                ["acc"] = TexAtomType.Accent,
+            };
         }
 
         private readonly XElement rootElement;
@@ -42,7 +38,7 @@ namespace XamlMath
             this.rootElement = doc.Root;
         }
 
-        public IDictionary<string, Func<SourceSpan?, SymbolAtom>> GetSymbols()
+        public IReadOnlyDictionary<string, Func<SourceSpan?, SymbolAtom>> GetSymbols()
         {
             var result = new Dictionary<string, Func<SourceSpan?, SymbolAtom>>();
 


### PR DESCRIPTION
This is a nudge towards immutability, which gives us greater piece of mind when coding.

In `XamlMath.Shared` there are methods that create mappings and lists to be looked up. These methods usually return arrays or lists that expose the `IList<T>` interface.

Where possible, the methods were made to return `IReadOnlyList<T>` or `IEnumerable<T>` instead. This makes their intent clearer (they are not to be modified, just used for lookup).

Similarly, some methods that return `IDictionary<TKey,TValue>` were made to return `IReadOnlyDictionary<TKey,TValue>`.

The types of the fields that store these lists or mappings were changed accordingly.

`internal` classes involved were `sealed`.

No changes to the public API.