### PR TITLE
Made singleton `Instance`s `readonly`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased] (2.1.1)
 ### Changed
 - The exception classes are now `sealed` (should not break anything, since there never was any sense in extending them in the user code).
+- Avalonia: `AvaloniaMathFontProvider::Instance` is now read-only.
 
 ## [2.1.0] - 2023-07-15
 ### Changed

--- a/api/AvaloniaMath.net462.verified.cs
+++ b/api/AvaloniaMath.net462.verified.cs
@@ -34,7 +34,7 @@ namespace AvaloniaMath.Fonts
     public sealed partial class AvaloniaMathFontProvider : XamlMath.Fonts.IFontProvider
     {
         internal AvaloniaMathFontProvider() { }
-        public static AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
+        public static readonly AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
         public XamlMath.Fonts.IFontTypeface ReadFontFile(string fontFileName) { throw null; }
     }
 }

--- a/api/AvaloniaMath.net6.0.verified.cs
+++ b/api/AvaloniaMath.net6.0.verified.cs
@@ -34,7 +34,7 @@ namespace AvaloniaMath.Fonts
     public sealed partial class AvaloniaMathFontProvider : XamlMath.Fonts.IFontProvider
     {
         internal AvaloniaMathFontProvider() { }
-        public static AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
+        public static readonly AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
         public XamlMath.Fonts.IFontTypeface ReadFontFile(string fontFileName) { throw null; }
     }
 }

--- a/api/AvaloniaMath.netstandard2.0.verified.cs
+++ b/api/AvaloniaMath.netstandard2.0.verified.cs
@@ -34,7 +34,7 @@ namespace AvaloniaMath.Fonts
     public sealed partial class AvaloniaMathFontProvider : XamlMath.Fonts.IFontProvider
     {
         internal AvaloniaMathFontProvider() { }
-        public static AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
+        public static readonly AvaloniaMath.Fonts.AvaloniaMathFontProvider Instance;
         public XamlMath.Fonts.IFontTypeface ReadFontFile(string fontFileName) { throw null; }
     }
 }

--- a/src/AvaloniaMath/Fonts/AvaloniaMathFontProvider.cs
+++ b/src/AvaloniaMath/Fonts/AvaloniaMathFontProvider.cs
@@ -7,7 +7,7 @@ public sealed class AvaloniaMathFontProvider : IFontProvider
 {
     private AvaloniaMathFontProvider() {}
 
-    public static AvaloniaMathFontProvider Instance = new();
+    public static readonly AvaloniaMathFontProvider Instance = new();
 
     public IFontTypeface ReadFontFile(string fontFileName)
     {

--- a/src/WpfMath/Fonts/WpfMathFontProvider.cs
+++ b/src/WpfMath/Fonts/WpfMathFontProvider.cs
@@ -11,7 +11,7 @@ internal sealed class WpfMathFontProvider : IFontProvider
 {
     private WpfMathFontProvider() {}
 
-    public static WpfMathFontProvider Instance = new();
+    public static readonly WpfMathFontProvider Instance = new();
 
     static WpfMathFontProvider()
     {


### PR DESCRIPTION
I know that this formally breaks the API, but it doesn't make sense to re-assign those static fields, and also they don't have any internal state, so nothing should break