### PR TITLE
Sealed more exception classes

### DIFF
--- a/api/XamlMath.Shared.net462.verified.cs
+++ b/api/XamlMath.Shared.net462.verified.cs
@@ -25,7 +25,7 @@ namespace XamlMath
         public double Size { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public XamlMath.CharFont GetCharacterFont() { throw null; }
     }
-    public partial class DelimiterMappingNotFoundException : System.Exception
+    public sealed partial class DelimiterMappingNotFoundException : System.Exception
     {
         internal DelimiterMappingNotFoundException() { }
     }
@@ -37,7 +37,7 @@ namespace XamlMath
         public XamlMath.CharInfo? Repeat { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public XamlMath.CharInfo? Top { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
-    public partial class FormulaNotFoundException : System.Exception
+    public sealed partial class FormulaNotFoundException : System.Exception
     {
         internal FormulaNotFoundException() { }
     }
@@ -63,11 +63,11 @@ namespace XamlMath
         public XamlMath.SourceSpan Segment(int start, int length) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class SymbolMappingNotFoundException : System.Exception
+    public sealed partial class SymbolMappingNotFoundException : System.Exception
     {
         internal SymbolMappingNotFoundException() { }
     }
-    public partial class SymbolNotFoundException : System.Exception
+    public sealed partial class SymbolNotFoundException : System.Exception
     {
         internal SymbolNotFoundException() { }
     }

--- a/api/XamlMath.Shared.net6.0.verified.cs
+++ b/api/XamlMath.Shared.net6.0.verified.cs
@@ -25,7 +25,7 @@ namespace XamlMath
         public double Size { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public XamlMath.CharFont GetCharacterFont() { throw null; }
     }
-    public partial class DelimiterMappingNotFoundException : System.Exception
+    public sealed partial class DelimiterMappingNotFoundException : System.Exception
     {
         internal DelimiterMappingNotFoundException() { }
     }
@@ -37,7 +37,7 @@ namespace XamlMath
         public XamlMath.CharInfo? Repeat { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public XamlMath.CharInfo? Top { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
-    public partial class FormulaNotFoundException : System.Exception
+    public sealed partial class FormulaNotFoundException : System.Exception
     {
         internal FormulaNotFoundException() { }
     }
@@ -63,11 +63,11 @@ namespace XamlMath
         public XamlMath.SourceSpan Segment(int start, int length) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class SymbolMappingNotFoundException : System.Exception
+    public sealed partial class SymbolMappingNotFoundException : System.Exception
     {
         internal SymbolMappingNotFoundException() { }
     }
-    public partial class SymbolNotFoundException : System.Exception
+    public sealed partial class SymbolNotFoundException : System.Exception
     {
         internal SymbolNotFoundException() { }
     }

--- a/api/XamlMath.Shared.netstandard2.0.verified.cs
+++ b/api/XamlMath.Shared.netstandard2.0.verified.cs
@@ -25,7 +25,7 @@ namespace XamlMath
         public double Size { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } [System.Runtime.CompilerServices.CompilerGeneratedAttribute] set { } }
         public XamlMath.CharFont GetCharacterFont() { throw null; }
     }
-    public partial class DelimiterMappingNotFoundException : System.Exception
+    public sealed partial class DelimiterMappingNotFoundException : System.Exception
     {
         internal DelimiterMappingNotFoundException() { }
     }
@@ -37,7 +37,7 @@ namespace XamlMath
         public XamlMath.CharInfo? Repeat { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
         public XamlMath.CharInfo? Top { [System.Runtime.CompilerServices.CompilerGeneratedAttribute] get { throw null; } }
     }
-    public partial class FormulaNotFoundException : System.Exception
+    public sealed partial class FormulaNotFoundException : System.Exception
     {
         internal FormulaNotFoundException() { }
     }
@@ -63,11 +63,11 @@ namespace XamlMath
         public XamlMath.SourceSpan Segment(int start, int length) { throw null; }
         public override string ToString() { throw null; }
     }
-    public partial class SymbolMappingNotFoundException : System.Exception
+    public sealed partial class SymbolMappingNotFoundException : System.Exception
     {
         internal SymbolMappingNotFoundException() { }
     }
-    public partial class SymbolNotFoundException : System.Exception
+    public sealed partial class SymbolNotFoundException : System.Exception
     {
         internal SymbolNotFoundException() { }
     }

--- a/src/XamlMath.Shared/DelimiterMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/DelimiterMappingNotFoundException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace XamlMath
 {
-    public class DelimiterMappingNotFoundException : Exception
+    public sealed class DelimiterMappingNotFoundException : Exception
     {
         internal DelimiterMappingNotFoundException(char delimiter)
             : base(string.Format("Cannot find delimeter mapping for the character '{0}'.", delimiter))

--- a/src/XamlMath.Shared/FormulaNotFoundException.cs
+++ b/src/XamlMath.Shared/FormulaNotFoundException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace XamlMath
 {
-    public class FormulaNotFoundException : Exception
+    public sealed class FormulaNotFoundException : Exception
     {
         internal FormulaNotFoundException(string formulaName)
             : base(string.Format("Cannot find predefined formula with name '{0}'.", formulaName))

--- a/src/XamlMath.Shared/SymbolMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/SymbolMappingNotFoundException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace XamlMath
 {
-    public class SymbolMappingNotFoundException : Exception
+    public sealed class SymbolMappingNotFoundException : Exception
     {
         internal SymbolMappingNotFoundException(string symbolName)
             : base(string.Format("Cannot find mapping for the symbol with name '{0}'.", symbolName))

--- a/src/XamlMath.Shared/SymbolNotFoundException.cs
+++ b/src/XamlMath.Shared/SymbolNotFoundException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace XamlMath
 {
-    public class SymbolNotFoundException : Exception
+    public sealed class SymbolNotFoundException : Exception
     {
         internal SymbolNotFoundException(string symbolName)
             : base(string.Format("Cannot find symbol with the name '{0}'.", symbolName))


### PR DESCRIPTION
Also, in the particular case of these exceptions, not only does it not make sense to inherit from them, but their constructors are `internal`, so there already wasn't any way of inheriting from them