### PR TITLE
`sealed` a few `internal` classes inheriting from `Box` and `Atom` in `XamlMath.Shared`

### DIFF
--- a/src/XamlMath.Shared/Atoms/AccentedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/AccentedAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing base atom with accent above it.
-    internal record AccentedAtom : Atom
+    internal sealed record AccentedAtom : Atom
     {
         public AccentedAtom(SourceSpan? source, Atom? baseAtom, string accentName)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/BigOperatorAtom.cs
+++ b/src/XamlMath.Shared/Atoms/BigOperatorAtom.cs
@@ -5,7 +5,7 @@ namespace XamlMath.Atoms
 {
     /// <summary>Atom representing big operator with optional limits.</summary>
     /// <param name="UseVerticalLimits">True if limits should be drawn over and under the base atom; false if they should be drawn as scripts.</param>
-    internal record BigOperatorAtom(
+    internal sealed record BigOperatorAtom(
         SourceSpan? Source,
         Atom? BaseAtom,
         Atom? LowerLimitAtom,

--- a/src/XamlMath.Shared/Atoms/CancelAtom.cs
+++ b/src/XamlMath.Shared/Atoms/CancelAtom.cs
@@ -2,7 +2,7 @@ using XamlMath.Boxes;
 
 namespace XamlMath.Atoms
 {
-    internal record CancelAtom : Atom
+    internal sealed record CancelAtom : Atom
     {
         private readonly Atom? _contentAtom;
         private readonly StrokeBoxMode _strokeBoxMode;

--- a/src/XamlMath.Shared/Atoms/CharAtom.cs
+++ b/src/XamlMath.Shared/Atoms/CharAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Utils;
 namespace XamlMath.Atoms
 {
     // Atom representing single character in specific text style.
-    internal record CharAtom : CharSymbol
+    internal sealed record CharAtom : CharSymbol
     {
         public CharAtom(SourceSpan? source, char character, string? textStyle = null)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/DummyAtom.cs
+++ b/src/XamlMath.Shared/Atoms/DummyAtom.cs
@@ -5,7 +5,7 @@ using XamlMath.Utils;
 namespace XamlMath.Atoms
 {
     // Dummy atom representing atom whose type can change or which can be replaced by a ligature.
-    internal record DummyAtom : Atom
+    internal sealed record DummyAtom : Atom
     {
         public DummyAtom(TexAtomType type, Atom atom, bool isTextSymbol)
             : base(atom.Source, type)

--- a/src/XamlMath.Shared/Atoms/FencedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/FencedAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing base atom surrounded by delimeters.
-    internal record FencedAtom : Atom
+    internal sealed record FencedAtom : Atom
     {
         private const int delimeterFactor = 901;
         private const double delimeterShortfall = 0.5;

--- a/src/XamlMath.Shared/Atoms/FixedCharAtom.cs
+++ b/src/XamlMath.Shared/Atoms/FixedCharAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Utils;
 namespace XamlMath.Atoms
 {
     // Atom representing character that does not depend on text style.
-    internal record FixedCharAtom : CharSymbol
+    internal sealed record FixedCharAtom : CharSymbol
     {
         public FixedCharAtom(SourceSpan? source, CharFont charFont)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/FractionAtom.cs
+++ b/src/XamlMath.Shared/Atoms/FractionAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing fraction, with or without separation line.
-    internal record FractionAtom : Atom
+    internal sealed record FractionAtom : Atom
     {
         private static TexAlignment CheckAlignment(TexAlignment alignment)
         {
@@ -71,7 +71,7 @@ namespace XamlMath.Atoms
         {
         }
 
-        protected FractionAtom(
+        private FractionAtom(
             SourceSpan? source,
             Atom? numerator,
             Atom? denominator,

--- a/src/XamlMath.Shared/Atoms/MatrixAtom.cs
+++ b/src/XamlMath.Shared/Atoms/MatrixAtom.cs
@@ -10,7 +10,7 @@ using SurroundingGap = System.Tuple<double, double>;
 namespace XamlMath.Atoms
 {
     /// <summary>An atom representing a tabular arrangement of atoms.</summary>
-    internal record MatrixAtom : Atom
+    internal sealed record MatrixAtom : Atom
     {
         /// <summary>Used for grouping of align statements into several columns.</summary>
         /// <remarks>

--- a/src/XamlMath.Shared/Atoms/NullAtom.cs
+++ b/src/XamlMath.Shared/Atoms/NullAtom.cs
@@ -2,7 +2,7 @@ using XamlMath.Boxes;
 
 namespace XamlMath.Atoms
 {
-    internal record NullAtom : Atom
+    internal sealed record NullAtom : Atom
     {
         public NullAtom(SourceSpan? source = null, TexAtomType type = TexAtomType.Ordinary) : base(source, type)
         {

--- a/src/XamlMath.Shared/Atoms/OverUnderDelimiter.cs
+++ b/src/XamlMath.Shared/Atoms/OverUnderDelimiter.cs
@@ -4,7 +4,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom with delimeter and script atoms over or under it.
-    internal record OverUnderDelimiter : Atom
+    internal sealed record OverUnderDelimiter : Atom
     {
         private static double GetMaxWidth(Box baseBox, Box delimeterBox, Box? scriptBox)
         {

--- a/src/XamlMath.Shared/Atoms/OverlinedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/OverlinedAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom with horizontal rule above it.
-    internal record OverlinedAtom : Atom
+    internal sealed record OverlinedAtom : Atom
     {
         public OverlinedAtom(SourceSpan? source, Atom? baseAtom)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/PhantomAtom.cs
+++ b/src/XamlMath.Shared/Atoms/PhantomAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom that is not rendered.
-    internal record PhantomAtom : Atom, IRow
+    internal sealed record PhantomAtom : Atom, IRow
     {
         private readonly bool useWidth;
         private readonly bool useHeight;

--- a/src/XamlMath.Shared/Atoms/Radical.cs
+++ b/src/XamlMath.Shared/Atoms/Radical.cs
@@ -6,7 +6,7 @@ namespace XamlMath.Atoms
     /// <summary>
     /// Atom representing radical (nth-root) construction.
     /// </summary>
-    internal record Radical : Atom
+    internal sealed record Radical : Atom
     {
         private const string sqrtSymbol = "sqrt";
 

--- a/src/XamlMath.Shared/Atoms/RowAtom.cs
+++ b/src/XamlMath.Shared/Atoms/RowAtom.cs
@@ -7,7 +7,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing horizontal row of other atoms, separated by glue.
-    internal record RowAtom : Atom, IRow
+    internal sealed record RowAtom : Atom, IRow
     {
         // Set of atom types that make previous atom of BinaryOperator type change to Ordinary type.
         private static readonly BitArray binaryOperatorChangeSet;

--- a/src/XamlMath.Shared/Atoms/ScriptsAtom.cs
+++ b/src/XamlMath.Shared/Atoms/ScriptsAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing scripts to attach to other atom.
-    internal record ScriptsAtom : Atom
+    internal sealed record ScriptsAtom : Atom
     {
         private static readonly SpaceAtom scriptSpaceAtom = new SpaceAtom(null, TexUnit.Point, 0.5, 0, 0);
 

--- a/src/XamlMath.Shared/Atoms/SpaceAtom.cs
+++ b/src/XamlMath.Shared/Atoms/SpaceAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing whitespace.
-    internal record SpaceAtom : Atom
+    internal sealed record SpaceAtom : Atom
     {
         // Collection of unit conversion functions.
         private static readonly UnitConversion[] unitConversions = new UnitConversion[]

--- a/src/XamlMath.Shared/Atoms/StyledAtom.cs
+++ b/src/XamlMath.Shared/Atoms/StyledAtom.cs
@@ -4,7 +4,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Atoms;
 
 /// <summary>Atom specifying graphical style.</summary>
-internal record StyledAtom : Atom, IRow
+internal sealed record StyledAtom : Atom, IRow
 {
     public StyledAtom(
         SourceSpan? source,

--- a/src/XamlMath.Shared/Atoms/TypedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/TypedAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom with custom left and right types.
-    internal record TypedAtom : Atom
+    internal sealed record TypedAtom : Atom
     {
         public TypedAtom(SourceSpan? source, Atom? atom, TexAtomType leftType, TexAtomType rightType)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/UnderOverAtom.cs
+++ b/src/XamlMath.Shared/Atoms/UnderOverAtom.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom with atoms optionally over and under it.
-    internal record UnderOverAtom : Atom
+    internal sealed record UnderOverAtom : Atom
     {
 #if !NET462 && !NETSTANDARD2_0
         [return: NotNullIfNotNull("box")]

--- a/src/XamlMath.Shared/Atoms/UnderlinedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/UnderlinedAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom that is underlined.
-    internal record UnderlinedAtom : Atom
+    internal sealed record UnderlinedAtom : Atom
     {
         public UnderlinedAtom(SourceSpan? source, Atom? baseAtom)
             : base(source)

--- a/src/XamlMath.Shared/Atoms/VerticalCenteredAtom.cs
+++ b/src/XamlMath.Shared/Atoms/VerticalCenteredAtom.cs
@@ -3,7 +3,7 @@ using XamlMath.Boxes;
 namespace XamlMath.Atoms
 {
     // Atom representing other atom vertically centered with respect to axis.
-    internal record VerticalCenteredAtom : Atom
+    internal sealed record VerticalCenteredAtom : Atom
     {
         public VerticalCenteredAtom(SourceSpan? source, Atom? atom)
             : base(source)

--- a/src/XamlMath.Shared/Boxes/CharBox.cs
+++ b/src/XamlMath.Shared/Boxes/CharBox.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Boxes;
 
 /// <summary>Box representing single character.</summary>
-internal class CharBox : Box
+internal sealed class CharBox : Box
 {
     public CharBox(TexEnvironment environment, CharInfo charInfo)
         : base(environment)

--- a/src/XamlMath.Shared/Boxes/GlueBox.cs
+++ b/src/XamlMath.Shared/Boxes/GlueBox.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Boxes
 {
     // Box representing glue.
-    internal class GlueBox : Box
+    internal sealed class GlueBox : Box
     {
         public GlueBox(double space, double stretch, double shrink)
         {

--- a/src/XamlMath.Shared/Boxes/HorizontalBox.cs
+++ b/src/XamlMath.Shared/Boxes/HorizontalBox.cs
@@ -4,7 +4,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Boxes
 {
     /// <summary>Box containing horizontal stack of child boxes.</summary>
-    internal class HorizontalBox : Box
+    internal sealed class HorizontalBox : Box
     {
         private double childBoxesTotalWidth = 0.0;
 

--- a/src/XamlMath.Shared/Boxes/HorizontalRule.cs
+++ b/src/XamlMath.Shared/Boxes/HorizontalRule.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Boxes
 {
     /// <summary>Box representing horizontal line.</summary>
-    internal class HorizontalRule : Box
+    internal sealed class HorizontalRule : Box
     {
         public HorizontalRule(TexEnvironment environment, double thickness, double width, double shift)
         {

--- a/src/XamlMath.Shared/Boxes/LayeredBox.cs
+++ b/src/XamlMath.Shared/Boxes/LayeredBox.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 
 namespace XamlMath.Boxes;
 
-internal class LayeredBox : Box
+internal sealed class LayeredBox : Box
 {
     public override void Add(Box box)
     {

--- a/src/XamlMath.Shared/Boxes/OverBar.cs
+++ b/src/XamlMath.Shared/Boxes/OverBar.cs
@@ -1,7 +1,7 @@
 namespace XamlMath.Boxes
 {
     // Box representing other box with horizontal rule above it.
-    internal class OverBar : VerticalBox
+    internal sealed class OverBar : VerticalBox
     {
         public OverBar(TexEnvironment environment, Box box, double kern, double thickness)
             : base()

--- a/src/XamlMath.Shared/Boxes/OverUnderBox.cs
+++ b/src/XamlMath.Shared/Boxes/OverUnderBox.cs
@@ -4,7 +4,7 @@ using XamlMath.Rendering.Transformations;
 namespace XamlMath.Boxes
 {
     // Box representing other box with delimiter and script box over or under it.
-    internal class OverUnderBox : Box
+    internal sealed class OverUnderBox : Box
     {
         public OverUnderBox(Box baseBox, Box delimiterBox, Box? scriptBox, double kern, bool over)
             : base()

--- a/src/XamlMath.Shared/Boxes/StrokeBox.cs
+++ b/src/XamlMath.Shared/Boxes/StrokeBox.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 
 namespace XamlMath.Boxes;
 
-internal class StrokeBox : Box
+internal sealed class StrokeBox : Box
 {
     private readonly StrokeBoxMode _mode;
 

--- a/src/XamlMath.Shared/Boxes/StrutBox.cs
+++ b/src/XamlMath.Shared/Boxes/StrutBox.cs
@@ -3,7 +3,7 @@ using XamlMath.Rendering;
 namespace XamlMath.Boxes
 {
     // Box representing whitespace.
-    internal class StrutBox : Box
+    internal sealed class StrutBox : Box
     {
         public static StrutBox Empty { get; } = new StrutBox(0, 0, 0, 0);
 


### PR DESCRIPTION
They are not part of the public interface, and no class is inheriting from them, so they should be fine to seal