### PR TITLE
`WpfMath.Converters.SVGConverter` now enumerates resulting strings with `yield return` instead of adding to `StringBuilder`

### DIFF
--- a/src/WpfMath/Converters/SVGConverter.cs
+++ b/src/WpfMath/Converters/SVGConverter.cs
@@ -8,8 +8,6 @@ namespace WpfMath.Converters;
 
 public class SVGConverter
 {
-    //private int m_nestedLevel = 0;
-
     public string ConvertGeometry(Geometry geometry)
     {
         if (geometry is not GeometryGroup group) return string.Empty;
@@ -18,7 +16,6 @@ public class SVGConverter
 
     private static IEnumerable<string> AddGeometry(GeometryGroup group)
     {
-        //m_nestedLevel++;
         if (!group.Transform.Value.IsIdentity)
         {
             yield return string.Format(
@@ -58,8 +55,6 @@ public class SVGConverter
             yield return Environment.NewLine;
             yield return Environment.NewLine;
         }
-
-        //m_nestedLevel--;
     }
 
     private static IEnumerable<string> AddGeometry(LineGeometry line)


### PR DESCRIPTION
Also, I'm not sure why `m_nestedLevel` is needed, so I commented it out, but the code is still there if it's needed