### PR TITLE
Collections (arrays, dictionaries) used in `DefaultTextFont` and `DefaultTexFontParser` now use read-only interfaces

### DIFF
--- a/src/XamlMath.Shared/DefaultTexFont.cs
+++ b/src/XamlMath.Shared/DefaultTexFont.cs
@@ -7,14 +7,14 @@ using XamlMath.Utils;
 namespace XamlMath;
 
 /// <summary>Default implementation of ITeXFont that reads all font information from XML file.</summary>
-internal class DefaultTexFont : ITeXFont
+internal sealed class DefaultTexFont : ITeXFont
 {
-    private readonly IDictionary<string, double> parameters;
-    private readonly IDictionary<string, object> generalSettings;
-    private readonly IDictionary<string, CharFont[]> textStyleMappings;
-    private readonly IDictionary<string, CharFont> symbolMappings;
-    internal readonly IList<string> defaultTextStyleMappings;
-    private readonly IList<TexFontInfo> fontInfoList;
+    private readonly IReadOnlyDictionary<string, double> parameters;
+    private readonly IReadOnlyDictionary<string, object> generalSettings;
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<CharFont>> textStyleMappings;
+    private readonly IReadOnlyDictionary<string, CharFont> symbolMappings;
+    internal readonly IReadOnlyList<string> defaultTextStyleMappings;
+    private readonly IReadOnlyList<TexFontInfo> fontInfoList;
 
     private double GetParameter(string name)
     {
@@ -121,7 +121,7 @@ internal class DefaultTexFont : ITeXFont
     public Result<CharInfo> GetDefaultCharInfo(char character, TexStyle style) =>
         this.GetCharInfo(character, GetDefaultTextStyleMapping(character), style);
 
-    private Result<CharInfo> GetCharInfo(char character, CharFont[] charFont, TexStyle style)
+    private Result<CharInfo> GetCharInfo(char character, IReadOnlyList<CharFont> charFont, TexStyle style)
     {
         TexCharKind charKind;
         int charIndexOffset;

--- a/src/XamlMath.Shared/DefaultTexFontParser.cs
+++ b/src/XamlMath.Shared/DefaultTexFontParser.cs
@@ -172,18 +172,18 @@ internal sealed class DefaultTexFontParser
 
     public IReadOnlyDictionary<string, object> GetGeneralSettings()
     {
-        var result = new Dictionary<string, object>();
-
         var generalSettings = rootElement.Element("GeneralSettings");
+
         if (generalSettings == null)
             throw new InvalidOperationException("Cannot find GeneralSettings element.");
 
-        result.Add("mufontid", generalSettings.AttributeInt32Value("mufontid"));
-        result.Add("spacefontid", generalSettings.AttributeInt32Value("spacefontid"));
-        result.Add("scriptfactor", generalSettings.AttributeDoubleValue("scriptfactor"));
-        result.Add("scriptscriptfactor", generalSettings.AttributeDoubleValue("scriptscriptfactor"));
-
-        return result;
+        return new Dictionary<string, object>
+        {
+            ["mufontid"] = generalSettings.AttributeInt32Value("mufontid"),
+            ["spacefontid"] = generalSettings.AttributeInt32Value("spacefontid"),
+            ["scriptfactor"] = generalSettings.AttributeDoubleValue("scriptfactor"),
+            ["scriptscriptfactor"] = generalSettings.AttributeDoubleValue("scriptscriptfactor"),
+        };
     }
 
     public IReadOnlyDictionary<string, IReadOnlyList<CharFont>> GetTextStyleMappings()

--- a/src/XamlMath.Shared/DefaultTexFontParser.cs
+++ b/src/XamlMath.Shared/DefaultTexFontParser.cs
@@ -216,10 +216,6 @@ internal sealed class DefaultTexFontParser
 
     public sealed class ExtensionParser : ICharChildParser
     {
-        public ExtensionParser()
-        {
-        }
-
         public void Parse(XElement element, char character, TexFontInfo fontInfo)
         {
             var extensionChars = new int[4];
@@ -237,10 +233,6 @@ internal sealed class DefaultTexFontParser
 
     public sealed class KernParser : ICharChildParser
     {
-        public KernParser()
-        {
-        }
-
         public void Parse(XElement element, char character, TexFontInfo fontInfo)
         {
             fontInfo.AddKern(character, (char)element.AttributeInt32Value("code"),
@@ -250,10 +242,6 @@ internal sealed class DefaultTexFontParser
 
     public sealed class LigParser : ICharChildParser
     {
-        public LigParser()
-        {
-        }
-
         public void Parse(XElement element, char character, TexFontInfo fontInfo)
         {
             fontInfo.AddLigature(character, (char)element.AttributeInt32Value("code"),
@@ -263,10 +251,6 @@ internal sealed class DefaultTexFontParser
 
     public sealed class NextLargerParser : ICharChildParser
     {
-        public NextLargerParser()
-        {
-        }
-
         public void Parse(XElement element, char character, TexFontInfo fontInfo)
         {
             fontInfo.SetNextLarger(character, (char)element.AttributeInt32Value("code"),

--- a/src/XamlMath.Shared/DefaultTexFontParser.cs
+++ b/src/XamlMath.Shared/DefaultTexFontParser.cs
@@ -214,7 +214,7 @@ internal sealed class DefaultTexFontParser
         return result;
     }
 
-    public class ExtensionParser : ICharChildParser
+    public sealed class ExtensionParser : ICharChildParser
     {
         public ExtensionParser()
         {
@@ -235,7 +235,7 @@ internal sealed class DefaultTexFontParser
         }
     }
 
-    public class KernParser : ICharChildParser
+    public sealed class KernParser : ICharChildParser
     {
         public KernParser()
         {
@@ -248,7 +248,7 @@ internal sealed class DefaultTexFontParser
         }
     }
 
-    public class LigParser : ICharChildParser
+    public sealed class LigParser : ICharChildParser
     {
         public LigParser()
         {
@@ -261,7 +261,7 @@ internal sealed class DefaultTexFontParser
         }
     }
 
-    public class NextLargerParser : ICharChildParser
+    public sealed class NextLargerParser : ICharChildParser
     {
         public NextLargerParser()
         {


### PR DESCRIPTION
They are never modified after their creation, but read-only interfaces make it clearer.

I also simplified some code in other ways, like removing unnecessary constructor bodies.