### PR TITLE
Shortened `new()` expressions in several places

### DIFF
--- a/src/WpfMath/Extensions.cs
+++ b/src/WpfMath/Extensions.cs
@@ -16,7 +16,7 @@ public static class Extensions
         var environment = WpfTeXEnvironment.Create(scale: scale, systemTextFontName: systemTextFontName);
         BitmapSource image = texForm.RenderToBitmap(environment, scale, x, y);
 
-        PngBitmapEncoder encoder = new PngBitmapEncoder();
+        PngBitmapEncoder encoder = new();
         encoder.Frames.Add(BitmapFrame.Create(image));
 
         using var ms = new MemoryStream();

--- a/src/WpfMath/Fonts/WpfSystemFont.cs
+++ b/src/WpfMath/Fonts/WpfSystemFont.cs
@@ -21,7 +21,7 @@ internal sealed class WpfSystemFont : ITeXFont
         _typeface = new Lazy<Typeface>(InitializeTypeface);
     }
 
-    private Typeface InitializeTypeface() => new Typeface(this.fontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
+    private Typeface InitializeTypeface() => new(this.fontFamily, FontStyles.Normal, FontWeights.Normal, FontStretches.Normal);
 
     public bool SupportsMetrics => false;
 

--- a/src/WpfMath/Rendering/WpfElementRenderer.cs
+++ b/src/WpfMath/Rendering/WpfElementRenderer.cs
@@ -24,7 +24,7 @@ internal sealed class WpfElementRenderer : IElementRenderer
     private readonly DrawingContext _targetContext;
     private readonly double _scale;
 
-    private readonly DrawingGroup _foregroundGroup = new DrawingGroup();
+    private readonly DrawingGroup _foregroundGroup = new();
     private readonly DrawingContext _foregroundContext;
 
     public WpfElementRenderer(DrawingContext targetContext, double scale)
@@ -107,10 +107,10 @@ internal sealed class WpfElementRenderer : IElementRenderer
         switch (transformation.Kind)
         {
             case TransformationKind.Translate:
-                var tt = (Transformation.Translate) transformation;
+                var tt = (Transformation.Translate)transformation;
                 return new TranslateTransform(tt.X, tt.Y);
             case TransformationKind.Rotate:
-                var rt = (Transformation.Rotate) transformation;
+                var rt = (Transformation.Rotate)transformation;
                 return new RotateTransform(rt.RotationDegrees);
             default:
                 throw new NotSupportedException($"Unknown {nameof(Transformation)} kind: {transformation.Kind}");
@@ -120,9 +120,9 @@ internal sealed class WpfElementRenderer : IElementRenderer
     /// <summary>
     /// Generates the guidelines for WPF render to snap the box boundaries onto the device pixel grid.
     /// </summary>
-    private GuidelineSet GenerateGuidelines(Box box, double x, double y) => new GuidelineSet
+    private GuidelineSet GenerateGuidelines(Box box, double x, double y) => new()
     {
-        GuidelinesX = {_scale * x, _scale * (x + box.TotalWidth)},
-        GuidelinesY = {_scale * y, _scale * (y + box.TotalHeight)}
+        GuidelinesX = { _scale * x, _scale * (x + box.TotalWidth) },
+        GuidelinesY = { _scale * y, _scale * (y + box.TotalHeight) }
     };
 }

--- a/src/XamlMath.Shared/Atoms/DummyAtom.cs
+++ b/src/XamlMath.Shared/Atoms/DummyAtom.cs
@@ -30,7 +30,7 @@ internal sealed record DummyAtom : Atom
     }
 
     public static DummyAtom CreateLigature(FixedCharAtom ligatureAtom) =>
-        new DummyAtom(TexAtomType.None, ligatureAtom, false);
+        new(TexAtomType.None, ligatureAtom, false);
 
     public Atom Atom { get; init; }
 

--- a/src/XamlMath.Shared/Atoms/ScriptsAtom.cs
+++ b/src/XamlMath.Shared/Atoms/ScriptsAtom.cs
@@ -6,7 +6,7 @@ namespace XamlMath.Atoms;
 // Atom representing scripts to attach to other atom.
 internal sealed record ScriptsAtom : Atom
 {
-    private static readonly SpaceAtom scriptSpaceAtom = new SpaceAtom(null, TexUnit.Point, 0.5, 0, 0);
+    private static readonly SpaceAtom scriptSpaceAtom = new(null, TexUnit.Point, 0.5, 0, 0);
 
     public ScriptsAtom(SourceSpan? source, Atom? baseAtom, Atom? subscriptAtom, Atom? superscriptAtom)
         : base(source)

--- a/src/XamlMath.Shared/Parsers/PredefinedFormulae/PredefinedFormulaContext.cs
+++ b/src/XamlMath.Shared/Parsers/PredefinedFormulae/PredefinedFormulaContext.cs
@@ -11,7 +11,7 @@ namespace XamlMath.Parsers.PredefinedFormulae;
 /// </summary>
 internal sealed class PredefinedFormulaContext
 {
-    private readonly Dictionary<string, TexFormula> _formulae = new Dictionary<string, TexFormula>();
+    private readonly Dictionary<string, TexFormula> _formulae = new();
     public void AddFormula(string name, TexFormula formula) => _formulae.Add(name, formula);
     public TexFormula this[string name] => _formulae[name];
 }

--- a/src/XamlMath.Shared/SourceSpan.cs
+++ b/src/XamlMath.Shared/SourceSpan.cs
@@ -32,12 +32,12 @@ public class SourceSpan : IEquatable<SourceSpan>
 
     public char this[int index] => this.Source[this.Start + index];
 
-    public SourceSpan Segment(int start) => new SourceSpan(SourceName, this.Source, this.Start + start, this.Length - start);
-    public SourceSpan Segment(int start, int length) => new SourceSpan(SourceName, this.Source, this.Start + start, length);
+    public SourceSpan Segment(int start) => new(SourceName, this.Source, this.Start + start, this.Length - start);
+    public SourceSpan Segment(int start, int length) => new(SourceName, this.Source, this.Start + start, length);
 
     public bool Equals(SourceSpan? other)
     {
-        if (ReferenceEquals(null, other)) return false;
+        if (other is null) return false;
         if (ReferenceEquals(this, other)) return true;
         return this.Start == other.Start
             && this.Length == other.Length
@@ -47,10 +47,10 @@ public class SourceSpan : IEquatable<SourceSpan>
 
     public override bool Equals(object? obj)
     {
-        if (ReferenceEquals(null, obj)) return false;
+        if (obj is null) return false;
         if (ReferenceEquals(this, obj)) return true;
         if (obj.GetType() != this.GetType()) return false;
-        return Equals((SourceSpan) obj);
+        return Equals((SourceSpan)obj);
     }
 
     public override int GetHashCode()

--- a/src/XamlMath.Shared/Utils/Result.cs
+++ b/src/XamlMath.Shared/Utils/Result.cs
@@ -4,8 +4,8 @@ namespace XamlMath.Utils;
 
 public static class Result
 {
-    public static Result<TValue> Ok<TValue>(TValue value) => new Result<TValue>(value, null);
-    public static Result<TValue> Error<TValue>(Exception error) => new Result<TValue>(default!, error); // Nullable: CS8604; can't be avoided with generics without constraints
+    public static Result<TValue> Ok<TValue>(TValue value) => new(value, null);
+    public static Result<TValue> Error<TValue>(Exception error) => new(default!, error); // Nullable: CS8604; can't be avoided with generics without constraints
 }
 
 public readonly struct Result<TValue>


### PR DESCRIPTION
The purpose is twofold: being more concise and reduce repetition.

Also, improved `null` checks in `Equals` methods of `SourceSpan`
