### PR TITLE
Converted `string.Format` to interpolated string

### DIFF
--- a/src/XamlMath.Shared/DefaultTexFontParser.cs
+++ b/src/XamlMath.Shared/DefaultTexFontParser.cs
@@ -78,7 +78,7 @@ internal sealed class DefaultTexFontParser
                     ProcessCharElement(charElement, fontInfo);
 
                 if (result[fontId] != null)
-                    throw new InvalidOperationException(string.Format("Multiple entries for font with ID {0}.", fontId));
+                    throw new InvalidOperationException($"Multiple entries for font with ID {fontId}.");
                 result[fontId] = fontInfo;
             }
         }
@@ -143,7 +143,6 @@ internal sealed class DefaultTexFontParser
             var codeMapping = rangeTypeMappings[code];
 
             var textStyleName = mappingElement.AttributeValue("textStyle");
-            var textStyleMapping = parsedTextStyles[textStyleName];
 
             var charFonts = parsedTextStyles[textStyleName];
             Debug.Assert(charFonts[codeMapping] != null);

--- a/src/XamlMath.Shared/DelimiterMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/DelimiterMappingNotFoundException.cs
@@ -5,7 +5,7 @@ namespace XamlMath;
 public sealed class DelimiterMappingNotFoundException : Exception
 {
     internal DelimiterMappingNotFoundException(char delimiter)
-        : base(string.Format("Cannot find delimeter mapping for the character '{0}'.", delimiter))
+        : base($"Cannot find delimeter mapping for the character '{delimiter}'.")
     {
     }
 }

--- a/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/Exceptions/TextStyleMappingNotFoundException.cs
@@ -3,7 +3,7 @@ namespace XamlMath.Exceptions;
 public sealed class TextStyleMappingNotFoundException : TexException
 {
     internal TextStyleMappingNotFoundException(string textStyleName)
-        : base(string.Format("Cannot find mapping for the style with name '{0}'.", textStyleName))
+        : base($"Cannot find mapping for the style with name '{textStyleName}'.")
     {
     }
 }

--- a/src/XamlMath.Shared/FormulaNotFoundException.cs
+++ b/src/XamlMath.Shared/FormulaNotFoundException.cs
@@ -5,7 +5,7 @@ namespace XamlMath;
 public sealed class FormulaNotFoundException : Exception
 {
     internal FormulaNotFoundException(string formulaName)
-        : base(string.Format("Cannot find predefined formula with name '{0}'.", formulaName))
+        : base($"Cannot find predefined formula with name '{formulaName}'.")
     {
     }
 }

--- a/src/XamlMath.Shared/SymbolMappingNotFoundException.cs
+++ b/src/XamlMath.Shared/SymbolMappingNotFoundException.cs
@@ -5,7 +5,7 @@ namespace XamlMath;
 public sealed class SymbolMappingNotFoundException : Exception
 {
     internal SymbolMappingNotFoundException(string symbolName)
-        : base(string.Format("Cannot find mapping for the symbol with name '{0}'.", symbolName))
+        : base($"Cannot find mapping for the symbol with name '{symbolName}'.")
     {
     }
 }

--- a/src/XamlMath.Shared/SymbolNotFoundException.cs
+++ b/src/XamlMath.Shared/SymbolNotFoundException.cs
@@ -5,7 +5,7 @@ namespace XamlMath;
 public sealed class SymbolNotFoundException : Exception
 {
     internal SymbolNotFoundException(string symbolName)
-        : base(string.Format("Cannot find symbol with the name '{0}'.", symbolName))
+        : base($"Cannot find symbol with the name '{symbolName}'.")
     {
     }
 }


### PR DESCRIPTION
Also, removed unnecessary dictionary lookup in `DefaultTexFontParser.cs`, in `GetDefaultTextStyleMappings()`. Notice that the variable just below the one that was deleted accesses the exact same value.