### PR TITLE
Inside `MainViewModel.Export()`, exception handling was made using a more specific exception type

### DIFF
--- a/src/WpfMath.Example/MainViewModel.cs
+++ b/src/WpfMath.Example/MainViewModel.cs
@@ -110,14 +110,14 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     private void Export()
     {
-        // Choose file
-        var saveFileDialog = new SaveFileDialog { Filter = "SVG Files (*.svg)|*.svg|PNG Files (*.png)|*.png" };
-        var result = saveFileDialog.ShowDialog();
-        if (result is false)
-            return;
-
         try
         {
+            // Choose file
+            var saveFileDialog = new SaveFileDialog { Filter = "SVG Files (*.svg)|*.svg|PNG Files (*.png)|*.png" };
+            var result = saveFileDialog.ShowDialog();
+            if (result is false)
+                return;
+
             // Create formula object from input text.
             TexFormula formula = WpfTeXFormulaParser.Instance.Parse(Formula);
             var scale = Scale;

--- a/src/WpfMath.Example/MainViewModel.cs
+++ b/src/WpfMath.Example/MainViewModel.cs
@@ -150,9 +150,6 @@ public sealed class MainViewModel : INotifyPropertyChanged
                     };
                     encoder.Save(stream);
                     break;
-
-                default:
-                    return;
             }
         }
         catch (TexParseException ex)
@@ -160,6 +157,10 @@ public sealed class MainViewModel : INotifyPropertyChanged
             MessageBox.Show("An error occurred while parsing the given input:" + Environment.NewLine +
                             Environment.NewLine + ex.Message, "WPF-Math Example",
                             MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show("An unknown error occurred: " + ex.Message);
         }
     }
 


### PR DESCRIPTION
This helps us get rid of the awkward variable assignment inside the `try` block, and we can just assign the variable directly