### PR TITLE
`TexFormulaParser.ReadElement` was modified so that it returns the updated position instead of mutating it

### DIFF
--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -35,7 +35,9 @@ internal sealed class MatrixCommandParser : ICommandParser, IEnvironmentParser
         if (position == source.Length)
             throw new TexParseException("illegal end!");
 
-        var cellsSource = TexFormulaParser.ReadElement(source, ref position);
+        var afterCells = TexFormulaParser.ReadElement(source, position);
+        position = afterCells.position;
+        var cellsSource = afterCells.source;
         var matrixSource = context.CommandSource.Segment(
             context.CommandNameStartPosition,
             position - context.CommandNameStartPosition);

--- a/src/XamlMath.Shared/Parsers/ProcessEnvironmentCommand.cs
+++ b/src/XamlMath.Shared/Parsers/ProcessEnvironmentCommand.cs
@@ -8,7 +8,9 @@ internal sealed class ProcessEnvironmentCommand : ICommandParser
     public CommandProcessingResult ProcessCommand(CommandContext context)
     {
         var position = context.ArgumentsStartPosition;
-        var environmentName = TexFormulaParser.ReadElement(context.CommandSource, ref position).ToString();
+        var afterElement = TexFormulaParser.ReadElement(context.CommandSource, position);
+        position = afterElement.position;
+        var environmentName = afterElement.source.ToString();
         if (environmentName == "") throw new TexParseException(@"Empty environment name for the \begin command.");
         if (!StandardCommands.Environments.TryGetValue(environmentName, out var environmentParser))
             throw new TexParseException(@$"Unknown environment name for the \begin command: ""{environmentName}"".");
@@ -32,7 +34,9 @@ internal sealed class ProcessEnvironmentCommand : ICommandParser
         {
             bodyEndPosition = position;
 
-            var element = TexFormulaParser.ReadElement(source, ref position);
+            var afterRead = TexFormulaParser.ReadElement(source, position);
+            position = afterRead.position;
+            var element = afterRead.source;
             switch (element.ToString())
             {
                 case @"\begin": ++nestingLevel; break;
@@ -45,7 +49,9 @@ internal sealed class ProcessEnvironmentCommand : ICommandParser
         if (nestingLevel != 0)
             throw new TexParseException(@$"No matching \end found for command ""\begin{{{environmentName}}}"".");
 
-        var endLabel = TexFormulaParser.ReadElement(source, ref position).ToString();
+        var afterEnd = TexFormulaParser.ReadElement(source, position);
+        position = afterEnd.position;
+        var endLabel = afterEnd.source.ToString();
         if (endLabel != environmentName)
             throw new TexParseException(
                 $@"""\end{{{endLabel}}}"" doesn't correspond to earlier ""\begin{{{environmentName}}}"".");

--- a/src/XamlMath.Shared/Parsers/StandardCommands.cs
+++ b/src/XamlMath.Shared/Parsers/StandardCommands.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO.Pipes;
 using XamlMath.Atoms;
 using XamlMath.Boxes;
 using XamlMath.Parsers.Matrices;
@@ -13,8 +14,10 @@ internal static class StandardCommands
         {
             var source = context.CommandSource;
             var position = context.ArgumentsStartPosition;
+            var afterFormula = TexFormulaParser.ReadElement(source, position);
+            position = afterFormula.position;
             var underlineFormula = context.Parser.Parse(
-                TexFormulaParser.ReadElement(source, ref position),
+                afterFormula.source,
                 context.Formula.TextStyle,
                 context.Environment);
             var start = context.CommandNameStartPosition;
@@ -30,12 +33,16 @@ internal static class StandardCommands
         {
             var source = context.CommandSource;
             var position = context.ArgumentsStartPosition;
+            var afterTop = TexFormulaParser.ReadElement(source, position);
+            position = afterTop.position;
             var topFormula = context.Parser.Parse(
-                        TexFormulaParser.ReadElement(source, ref position),
+                        afterTop.source,
                         context.Formula.TextStyle,
                         context.Environment.CreateChildEnvironment());
+            var afterBottom = TexFormulaParser.ReadElement(source, position);
+            position = afterBottom.position;
             var bottomFormula = context.Parser.Parse(
-                        TexFormulaParser.ReadElement(source, ref position),
+                        afterBottom.source,
                         context.Formula.TextStyle,
                         context.Environment.CreateChildEnvironment());
             var start = context.CommandNameStartPosition;
@@ -68,7 +75,9 @@ internal static class StandardCommands
         {
             var source = context.CommandSource;
             var position = context.ArgumentsStartPosition;
-            var contentFormula = context.Parser.Parse(TexFormulaParser.ReadElement(source, ref position),
+            var afterFormula = TexFormulaParser.ReadElement(source, position);
+            position = afterFormula.position;
+            var contentFormula = context.Parser.Parse(afterFormula.source,
                                                       context.Formula.TextStyle,
                                                       context.Environment.CreateChildEnvironment());
 


### PR DESCRIPTION
Similar to #489, but the number of changes is enough to need its own pull request.

The end goal is having the `TexFormulaParser` returning the new values instead of mutating the existing ones.